### PR TITLE
fix for Python3

### DIFF
--- a/package/main.py
+++ b/package/main.py
@@ -41,7 +41,7 @@ def csvdata():
         return json.dumps({error:
                            'You are not allowed to upload such a file.'})
     else:
-        flist = [f.replace('./data/', '').replace('.csv', '')
+        flist = [f.replace('./data'+os.sep, '').replace('.csv', '')
                  for f in glob.glob('./data/*.csv')]
         return json.dumps(flist)
 
@@ -66,7 +66,7 @@ def getdata(dataname):
             if headerOnly:
                 return jsonify(name=dataname, csv=csvfile.readline())
             else:
-                return jsonify(name=dataname, csv=csvfile.read())
+                return jsonify(name=dataname, csv=csvfile.read().decode("UTF-8"))
 
 
 @app.route('/ml/cls/<action>', methods=['GET'])


### PR DESCRIPTION
环境Windows 7+Python 3(Anaconda3)中
报错 raise TypeError(repr(o) + " is not JSON serializable")
因为Python3中read输出类型为bytes
